### PR TITLE
feat: add page for Trae

### DIFF
--- a/docs/trae.md
+++ b/docs/trae.md
@@ -1,0 +1,26 @@
+---
+tags:
+  - cli
+  - agent
+---
+
+# Trae
+
+| Website | GitHub | License |
+| --- | --- | --- |
+| [bytedance/trae-agent](https://github.com/bytedance/trae-agent) | [bytedance/trae-agent](https://github.com/bytedance/trae-agent) | Apache 2.0 |
+
+**Trae Agent is an LLM-based agent for general-purpose software engineering tasks.**
+
+Trae Agent is a command-line tool that uses large language models to understand natural language instructions and perform complex software engineering tasks. It supports multiple LLM providers and has a rich ecosystem of tools.
+
+### Key Features
+
+*   **Multi-LLM Support:** Works with OpenAI, Anthropic, Google Gemini, and other LLM providers.
+*   **Rich Tool Ecosystem:** Includes tools for file editing, shell execution, and more.
+*   **Interactive Mode:** Offers a conversational interface for iterative development.
+*   **Trajectory Recording:** Logs all agent actions for debugging and analysis.
+
+## Links
+
+*   **GitHub:** https://github.com/bytedance/trae-agent

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,3 +58,4 @@ nav:
     - Ruler: ruler.md
     - Vibe Kanban: vibe-kanban.md
     - Zed: zed.md
+    - Trae: trae.md


### PR DESCRIPTION
Adds a new page for the Trae agent to the website. Fixes #9